### PR TITLE
fix syntax and shebang

### DIFF
--- a/snap
+++ b/snap
@@ -1,11 +1,11 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Grabs a snapshot of a USB connected Android device. 
 
-if [[ -z $1 ]]; then
-	fileName="$(date +%F_%H.%M.%S).png"
+if [[ -z "${1}" ]]; then
+    fileName="$(date +%F_%H.%M.%S).png"
 else 
-	fileName="${1}.png"  
+    fileName="${1}.png"
 fi
 
 adb shell screencap -p | perl -pe 's/\x0D\x0A/\x0A/g' > $fileName


### PR DESCRIPTION
Hi snapwire,

a few minor fixes in here:
- the Shebang was pointing to `/bin/sh`, but the script uses Bash specifics. Changing that to `/bin/bash` made it work correctly (line 1)
- just in case: testing for an empty string is safer when enclosing it in quotes (line 5)
- converted tabs to spaces (lines 6+8)

Thanks for the script – and I hope you find my little changes helpful :smile_cat: 
